### PR TITLE
test: Add e2e test for Deployment and DaemonSet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require (
 	github.com/google/go-containerregistry v0.4.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
+	k8s.io/client-go v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/test/cloner/daemonset_cloner_test.go
+++ b/test/cloner/daemonset_cloner_test.go
@@ -1,0 +1,115 @@
+// +build e2e
+
+package cloner_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/impochi/cloner/pkg/registry"
+	"github.com/impochi/cloner/test/util"
+)
+
+const daemonsetManifest = `apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: prometheus-daemonset
+spec:
+  selector:
+    matchLabels:
+      tier: monitoring
+      name: prometheus-exporter
+  template:
+    metadata:
+      labels:
+        tier: monitoring
+        name: prometheus-exporter
+    spec:
+      initContainers:
+      - name: init-1
+        image: busybox:1.33.0
+        command: ['sh', '-c', 'echo Init Container executing!']
+      containers:
+      - name: prometheus
+        image: prom/node-exporter
+        ports:
+        - containerPort: 80
+`
+
+func TestDaemonSetImageClone(t *testing.T) {
+
+	client := util.CreateKubernetesClient(t)
+
+	namespace := &corev1.Namespace{}
+	if err := yaml.Unmarshal([]byte(NamespaceManifest), namespace); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create Namespace: %v", err)
+	}
+
+	daemonset := &appsv1.DaemonSet{}
+	if err := yaml.Unmarshal([]byte(daemonsetManifest), daemonset); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	initContainerImage := daemonset.Spec.Template.Spec.InitContainers[0].Image
+	containerImage := daemonset.Spec.Template.Spec.Containers[0].Image
+
+	dstInitContainerImage, err := registry.GetDestinationImage(initContainerImage)
+	if err != nil {
+		t.Fatalf("failed to get destination image: %v", err)
+	}
+	dstContainerImage, err := registry.GetDestinationImage(containerImage)
+	if err != nil {
+		t.Fatalf("failed to get destination image: %v", err)
+	}
+
+	daemonset, err = client.AppsV1().DaemonSets(namespace.Name).Create(context.TODO(), daemonset, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create DaemonSet: %v", err)
+	}
+
+	// wait for 1 minute so that the image is cloned and daemonset updaed by the cloner controller.
+	// TODO: implement dynamic wait, that checks if the daemonset is ready or not before proceeding.
+	time.Sleep(1 * time.Minute)
+
+	daemonset, err = client.AppsV1().DaemonSets(namespace.Name).Get(context.TODO(), daemonset.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to create DaemonSet: %v", err)
+	}
+
+	initContainerImage = daemonset.Spec.Template.Spec.InitContainers[0].Image
+	containerImage = daemonset.Spec.Template.Spec.Containers[0].Image
+
+	if dstInitContainerImage != initContainerImage {
+		t.Fatalf("expected %q, got %q", dstInitContainerImage, initContainerImage)
+	}
+
+	if dstContainerImage != containerImage {
+		t.Fatalf("expected %q, got %q", dstContainerImage, containerImage)
+	}
+
+	t.Cleanup(func() {
+		if err := client.AppsV1().DaemonSets(namespace.Name).Delete(
+			context.TODO(), daemonset.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove DaemonSet: %v", err)
+		}
+
+		if err := client.CoreV1().Namespaces().Delete(
+			context.TODO(), namespace.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove Namespace: %v", err)
+		}
+
+		util.WaitForNamespaceToBeDeleted(t, client, namespace.ObjectMeta.Name, time.Second*5, time.Minute*5)
+	})
+
+}

--- a/test/cloner/deployment_cloner_test.go
+++ b/test/cloner/deployment_cloner_test.go
@@ -1,0 +1,122 @@
+// +build e2e
+
+package cloner_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/impochi/cloner/pkg/registry"
+	"github.com/impochi/cloner/test/util"
+)
+
+const NamespaceManifest = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e
+`
+
+const deploymentManifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      initContainers:
+      - name: init-1
+        image: busybox:1.33.0
+        command: ['sh', '-c', 'echo Init Container executing!']
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+`
+
+func TestDeploymentImageClone(t *testing.T) {
+
+	client := util.CreateKubernetesClient(t)
+
+	namespace := &corev1.Namespace{}
+	if err := yaml.Unmarshal([]byte(NamespaceManifest), namespace); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create Namespace: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := yaml.Unmarshal([]byte(deploymentManifest), deployment); err != nil {
+		t.Fatalf("failed unmarshaling manifest: %v", err)
+	}
+
+	initContainerImage := deployment.Spec.Template.Spec.InitContainers[0].Image
+	containerImage := deployment.Spec.Template.Spec.Containers[0].Image
+
+	dstInitContainerImage, err := registry.GetDestinationImage(initContainerImage)
+	if err != nil {
+		t.Fatalf("failed to get destination image: %v", err)
+	}
+
+	dstContainerImage, err := registry.GetDestinationImage(containerImage)
+	if err != nil {
+		t.Fatalf("failed to get destination image: %v", err)
+	}
+
+	deployment, err = client.AppsV1().Deployments(namespace.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create Deployment: %v", err)
+	}
+
+	// wait for 1 minute so that the image is cloned and deployment updated by the cloner controller.
+	// TODO: implement dynamic wait, that checks if the deployment is ready or not before proceeding.
+	time.Sleep(1 * time.Minute)
+
+	deployment, err = client.AppsV1().Deployments(namespace.Name).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to create Deployment: %v", err)
+	}
+
+	initContainerImage = deployment.Spec.Template.Spec.InitContainers[0].Image
+	containerImage = deployment.Spec.Template.Spec.Containers[0].Image
+
+	if dstInitContainerImage != initContainerImage {
+		t.Fatalf("expected %q, got %q", dstInitContainerImage, initContainerImage)
+	}
+
+	if dstContainerImage != containerImage {
+		t.Fatalf("expected %q, got %q", dstContainerImage, containerImage)
+	}
+
+	t.Cleanup(func() {
+		if err := client.AppsV1().Deployments(namespace.Name).Delete(
+			context.TODO(), deployment.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove Deployment: %v", err)
+		}
+
+		if err := client.CoreV1().Namespaces().Delete(
+			context.TODO(), namespace.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("failed to remove Namespace: %v", err)
+		}
+
+		util.WaitForNamespaceToBeDeleted(t, client, namespace.ObjectMeta.Name, time.Second*5, time.Minute*5)
+	})
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// RetryInterval is time for test to retry.
+	RetryInterval = time.Second * 5
+	// Timeout is time after which tests stops and fails.
+	Timeout = time.Minute * 2
+)
+
+func CreateKubernetesClient(t *testing.T) *kubernetes.Clientset {
+	kubeconfigPath := os.ExpandEnv(os.Getenv("KUBECONFIG"))
+	if kubeconfigPath == "" {
+		t.Fatalf("env var KUBECONFIG was not set")
+	}
+
+	c, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		t.Fatalf("failed building rest client: %v", err)
+	}
+
+	cs, err := kubernetes.NewForConfig(c)
+	if err != nil {
+		t.Fatalf("failed creating new clientset: %v", err)
+	}
+
+	return cs
+}
+
+func WaitForNamespaceToBeDeleted(t *testing.T, client kubernetes.Interface, name string, retryInterval, timeout time.Duration) {
+	if err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+		_, err = client.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				t.Logf("namespace %s deleted", name)
+				return true, nil
+			}
+
+			return false, nil
+		}
+
+		return false, nil
+
+	}); err != nil {
+		t.Fatalf("waiting for the namespace to be deleted: %v", err)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -284,6 +284,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.20.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
@@ -416,4 +417,5 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml


### PR DESCRIPTION
This commit adds e2e tests for Deployment and DaemonSet.
The test currently expects the Cloner controller to be deployed.

The test installs an example Deployment and DaemonSet and expects the
images of its containers and initContainers to be backed up in the
provided container registry and username.

Fixes #1 

Signed-off-by: Imran Pochi <official.immi@gmail.com>