### PR TITLE
Add lint option and golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,69 @@
+run:
+  build-tags:
+    - e2e
+
+  modules-download-mode: vendor
+  new-from-rev: origin/main
+
+  timeout: 5m
+
+issues:
+  exclude-use-default: false
+  max-same-issues: 0
+  max-issues-per-linter: 0
+
+linters:
+  disable-all: false
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - exhaustive
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomnd
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - nlreturn
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - testpackage
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - wsl
+

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,14 @@ docker-build:
 .PHONY: test
 test:
 	go test -mod=vendor -buildmode=exe ./...
+
+.PHONY: lint
+lint: build test lint-bin
+
+.PHONY: lint-bin
+lint-bin:
+	golangci-lint run ./...
+
+.PHONY: lint-docker
+lint-docker:
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.30.0 make lint

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -1,3 +1,4 @@
+// Package cmd handles the cli options for the controller.
 package cmd
 
 import (
@@ -8,10 +9,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var (
-	ignoreNamespaces string
-)
+var ignoreNamespaces string
 
+// Execute executes and initiates the cli flags, creates config.
 func Execute() {
 	flag.StringVar(&ignoreNamespaces, "ignore-namespaces", "kube-system", "Namespaces to ignore when cloning images")
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,3 +1,4 @@
+// Package config handles the configuration of the controller.
 package config
 
 import (
@@ -7,21 +8,27 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// Config represents the configuration for the controller.
 type Config struct {
 	IgnoreNamespaces []string
 	Logger           logr.Logger
 }
 
+// ParseIgnoreNamespaces parses the namespaces string provided by the user
+// into a list of strings based on the comma separator.
+// Appends the `kube-system` and CONTROLLER_NAMESPACEto the string and removes
+// the duplicates.
 func (c *Config) ParseIgnoreNamespaces(namespaces string) {
 	ns := strings.Split(namespaces, ",")
 
-	// Append controller namespace and kube-system namespace
+	// Append controller namespace and kube-system namespace.
 	controllerNs := os.Getenv("CONTROLLER_NAMESPACE")
 	ns = append(ns, controllerNs, "kube-system")
 	ignoredNamespaces := []string{}
 
-	// Remove duplicate names and empty strings from the namespaces input.
 	dupl := map[string]string{}
+
+	// Remove duplicate names and empty strings from the namespaces input.
 	for _, value := range ns {
 		value := strings.TrimSpace(value)
 

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -12,7 +12,9 @@ const testNamespace = "test-ns"
 func TestParseIgnoreNamespaces(t *testing.T) {
 	cfg := &config.Config{}
 
-	os.Setenv("CONTROLLER_NAMESPACE", testNamespace)
+	if err := os.Setenv("CONTROLLER_NAMESPACE", testNamespace); err != nil {
+		t.Fatalf("Failed to set env variable `CONTROLLER_NAMESPACE`")
+	}
 
 	cases := []struct {
 		namespaces string
@@ -21,7 +23,8 @@ func TestParseIgnoreNamespaces(t *testing.T) {
 		{
 			namespaces: "",
 			wanted:     []string{"kube-system", testNamespace},
-		}, {
+		},
+		{
 			namespaces: "default,kube-system,default",
 			wanted:     []string{"default", "kube-system", testNamespace},
 		},

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,3 +1,5 @@
+// Package controller handles the logic of Image clone controller, watching the resources
+// and reconciling objects with the Kubernetes API server.
 package controller
 
 import (
@@ -6,24 +8,28 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	pkglog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	pkgregistry "github.com/impochi/cloner/pkg/registry"
 )
 
+// ClonerReconciler is the controller's reconciler object.
 type ClonerReconciler struct {
 	Client client.Client
 }
 
+// Reconcile reconciles the object that is in question. In this case its either a Deployment or
+// DaemonSet.
 func (cr *ClonerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := log.FromContext(ctx)
+	log := pkglog.FromContext(ctx)
 
 	// Get the Deployents or DaemonSet from the cache
 	deployment := &appsv1.Deployment{}
 	daemonset := &appsv1.DaemonSet{}
 
 	kind := "Deployment"
+
 	err := cr.Client.Get(ctx, req.NamespacedName, deployment)
 	if errors.IsNotFound(err) {
 		log.Info("not a Deployment, checking for Daemonset")
@@ -40,99 +46,18 @@ func (cr *ClonerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	if err != nil {
 		log.Error(err, "could not fetch Deployment or DaemonSet")
+
 		return reconcile.Result{}, err
 	}
 
 	log.Info("reconciling Deployment", "deployment name", deployment.Name)
 
 	if kind == "Deployment" && isDeploymentReady(deployment) {
-		needsUpdate := false
-		for index, container := range deployment.Spec.Template.Spec.InitContainers {
-			dstImage, err := pkgregistry.GetDestinationImage(container.Image)
-			if err != nil {
-				log.Error(err, "failed to get destination image")
-				return reconcile.Result{}, err
-			}
-			if container.Image != dstImage {
-				if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
-					log.Error(err, "failed to push image")
-					return reconcile.Result{}, err
-				}
-
-				deployment.Spec.Template.Spec.InitContainers[index].Image = dstImage
-				needsUpdate = true
-			}
-		}
-
-		for index, container := range deployment.Spec.Template.Spec.Containers {
-			dstImage, err := pkgregistry.GetDestinationImage(container.Image)
-			if err != nil {
-				log.Error(err, "failed to get destination image")
-				return reconcile.Result{}, err
-			}
-			if container.Image != dstImage {
-				if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
-					log.Error(err, "failed to push image")
-					return reconcile.Result{}, err
-				}
-
-				deployment.Spec.Template.Spec.Containers[index].Image = dstImage
-				needsUpdate = true
-			}
-		}
-
-		// Update Deployment
-		if needsUpdate {
-			if err := cr.Client.Update(ctx, deployment); err != nil {
-				log.Error(err, "failed to update Deployment")
-				return reconcile.Result{}, err
-			}
-		}
+		return cr.reconcileDeployment(ctx, deployment)
 	}
 
 	if kind == "DaemonSet" && isDaemonSetReady(daemonset) {
-		needsUpdate := false
-		for index, container := range daemonset.Spec.Template.Spec.InitContainers {
-			dstImage, err := pkgregistry.GetDestinationImage(container.Image)
-			if err != nil {
-				log.Error(err, "failed to get destination image")
-				return reconcile.Result{}, err
-			}
-			if container.Image != dstImage {
-				if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
-					log.Error(err, "failed to push image")
-					return reconcile.Result{}, err
-				}
-
-				daemonset.Spec.Template.Spec.InitContainers[index].Image = dstImage
-				needsUpdate = true
-			}
-		}
-
-		for index, container := range daemonset.Spec.Template.Spec.Containers {
-			dstImage, err := pkgregistry.GetDestinationImage(container.Image)
-			if err != nil {
-				log.Error(err, "failed to get destination image")
-				return reconcile.Result{}, err
-			}
-			if container.Image != dstImage {
-				if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
-					log.Error(err, "failed to push image")
-					return reconcile.Result{}, err
-				}
-
-				daemonset.Spec.Template.Spec.Containers[index].Image = dstImage
-				needsUpdate = true
-			}
-		}
-
-		// Update Daemonset
-		if needsUpdate {
-			if err := cr.Client.Update(ctx, daemonset); err != nil {
-				log.Error(err, "failed to update DaemonSet")
-				return reconcile.Result{}, err
-			}
-		}
+		return cr.reconcileDaemonSet(ctx, daemonset)
 	}
 
 	return reconcile.Result{}, nil
@@ -141,6 +66,7 @@ func (cr *ClonerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 func isDaemonSetReady(ds *appsv1.DaemonSet) bool {
 	status := ds.Status
 	desired := status.DesiredNumberScheduled
+
 	ready := status.NumberReady
 	if desired == ready && desired > 0 {
 		return true
@@ -153,9 +79,125 @@ func isDeploymentReady(deployments *appsv1.Deployment) bool {
 	status := deployments.Status
 	desired := status.Replicas
 	ready := status.ReadyReplicas
+
 	if desired == ready && desired > 0 {
 		return true
 	}
 
 	return false
+}
+
+func (cr *ClonerReconciler) reconcileDeployment(ctx context.Context,
+	deployment *appsv1.Deployment) (reconcile.Result, error) {
+	log := pkglog.FromContext(ctx)
+
+	needsUpdate := false
+
+	for index, container := range deployment.Spec.Template.Spec.InitContainers {
+		dstImage, err := pkgregistry.GetDestinationImage(container.Image)
+		if err != nil {
+			log.Error(err, "failed to get destination image")
+
+			return reconcile.Result{}, err
+		}
+
+		if container.Image != dstImage {
+			if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
+				log.Error(err, "failed to push image")
+
+				return reconcile.Result{}, err
+			}
+
+			deployment.Spec.Template.Spec.InitContainers[index].Image = dstImage
+			needsUpdate = true
+		}
+	}
+
+	for index, container := range deployment.Spec.Template.Spec.Containers {
+		dstImage, err := pkgregistry.GetDestinationImage(container.Image)
+		if err != nil {
+			log.Error(err, "failed to get destination image")
+
+			return reconcile.Result{}, err
+		}
+
+		if container.Image != dstImage {
+			if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
+				log.Error(err, "failed to push image")
+
+				return reconcile.Result{}, err
+			}
+
+			deployment.Spec.Template.Spec.Containers[index].Image = dstImage
+			needsUpdate = true
+		}
+	}
+	// Update Deployment
+	if needsUpdate {
+		if err := cr.Client.Update(ctx, deployment); err != nil {
+			log.Error(err, "failed to update Deployment")
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (cr *ClonerReconciler) reconcileDaemonSet(ctx context.Context,
+	daemonset *appsv1.DaemonSet) (reconcile.Result, error) {
+	log := pkglog.FromContext(ctx)
+
+	needsUpdate := false
+
+	for index, container := range daemonset.Spec.Template.Spec.InitContainers {
+		dstImage, err := pkgregistry.GetDestinationImage(container.Image)
+		if err != nil {
+			log.Error(err, "failed to get destination image")
+
+			return reconcile.Result{}, err
+		}
+
+		if container.Image != dstImage {
+			if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
+				log.Error(err, "failed to push image")
+
+				return reconcile.Result{}, err
+			}
+
+			daemonset.Spec.Template.Spec.InitContainers[index].Image = dstImage
+			needsUpdate = true
+		}
+	}
+
+	for index, container := range daemonset.Spec.Template.Spec.Containers {
+		dstImage, err := pkgregistry.GetDestinationImage(container.Image)
+		if err != nil {
+			log.Error(err, "failed to get destination image")
+
+			return reconcile.Result{}, err
+		}
+
+		if container.Image != dstImage {
+			if err := pkgregistry.Backup(container.Image, dstImage); err != nil {
+				log.Error(err, "failed to push image")
+
+				return reconcile.Result{}, err
+			}
+
+			daemonset.Spec.Template.Spec.Containers[index].Image = dstImage
+			needsUpdate = true
+		}
+	}
+
+	// Update Daemonset
+	if needsUpdate {
+		if err := cr.Client.Update(ctx, daemonset); err != nil {
+			log.Error(err, "failed to update DaemonSet")
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,3 +1,5 @@
+// Package registry handles the registry relation functionality such as pushing
+// the container image to the provided registry, fetching registry credentials.
 package registry
 
 import (
@@ -32,13 +34,17 @@ func fetchCredentials() (*registryCredentials, error) {
 	}, nil
 }
 
+// GetDestinationImage returns the name of the destination image.
 func GetDestinationImage(srcImage string) (string, error) {
 	dstImage := ""
+
 	creds, err := fetchCredentials()
 	if err != nil {
 		return dstImage, err
 	}
+
 	repo, tag := getRepoAndTagFromImage(srcImage)
+
 	if len(creds.provider) != 0 {
 		dstImage += fmt.Sprintf("%s/", creds.provider)
 	}
@@ -52,6 +58,7 @@ func GetDestinationImage(srcImage string) (string, error) {
 	return dstImage, nil
 }
 
+// Backup pushes the docker image to the provided repository.
 func Backup(srcImage, dstImage string) error {
 	srcRef, err := getReference(srcImage)
 	if err != nil {
@@ -93,7 +100,9 @@ func getRepoAndTagFromImage(image string) (repository, tag string) {
 	}
 
 	str := strings.Split(image, ":")
+
 	imageWithoutTag := str[0]
+
 	if len(str) == 1 {
 		tag = ""
 	} else {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package registry
 
 import (
@@ -56,19 +57,26 @@ func TestFetchCredentials(t *testing.T) {
 	}
 
 	for _, testcase := range cases {
-		os.Setenv("REGISTRY_PROVIDER", testcase.provider)
-		os.Setenv("REGISTRY_USERNAME", testcase.username)
-		os.Setenv("REGISTRY_PASSWORD", testcase.password)
+		if err := os.Setenv("REGISTRY_PROVIDER", testcase.provider); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
+
+		if err := os.Setenv("REGISTRY_USERNAME", testcase.username); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
+
+		if err := os.Setenv("REGISTRY_PASSWORD", testcase.password); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
 
 		_, err := fetchCredentials()
 		if err != nil && !testcase.expectErr {
 			t.Errorf("Failed to fetch credentials: %v", err)
 		}
 	}
-
 }
 
-func TestGetDestinationImage(t *testing.T) {
+func TestGetDestinationImage(t *testing.T) { //nolint:funlen
 	cases := []struct {
 		provider string
 		username string
@@ -114,9 +122,17 @@ func TestGetDestinationImage(t *testing.T) {
 	}
 
 	for _, testcase := range cases {
-		os.Setenv("REGISTRY_PROVIDER", testcase.provider)
-		os.Setenv("REGISTRY_USERNAME", testcase.username)
-		os.Setenv("REGISTRY_PASSWORD", password)
+		if err := os.Setenv("REGISTRY_PROVIDER", testcase.provider); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
+
+		if err := os.Setenv("REGISTRY_USERNAME", testcase.username); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
+
+		if err := os.Setenv("REGISTRY_PASSWORD", password); err != nil {
+			t.Fatalf("Failed to set env variable `REGISTRY_PROVIDER`: %q", err)
+		}
 
 		dst, err := GetDestinationImage(testcase.input)
 		if err != nil {
@@ -163,6 +179,7 @@ func TestGetRepoAndTagFromImage(t *testing.T) {
 		if testcase.repo != imagerepo {
 			t.Errorf("Expected repository name as %q, got %q", testcase.repo, imagerepo)
 		}
+
 		if testcase.tag != imagetag {
 			t.Errorf("Expected repository name as %q, got %q", testcase.tag, imagetag)
 		}

--- a/test/cloner/daemonset_cloner_test.go
+++ b/test/cloner/daemonset_cloner_test.go
@@ -42,8 +42,8 @@ spec:
         - containerPort: 80
 `
 
+//nolint:funlen
 func TestDaemonSetImageClone(t *testing.T) {
-
 	client := util.CreateKubernetesClient(t)
 
 	namespace := &corev1.Namespace{}
@@ -68,6 +68,7 @@ func TestDaemonSetImageClone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get destination image: %v", err)
 	}
+
 	dstContainerImage, err := registry.GetDestinationImage(containerImage)
 	if err != nil {
 		t.Fatalf("failed to get destination image: %v", err)
@@ -111,5 +112,4 @@ func TestDaemonSetImageClone(t *testing.T) {
 
 		util.WaitForNamespaceToBeDeleted(t, client, namespace.ObjectMeta.Name, time.Second*5, time.Minute*5)
 	})
-
 }

--- a/test/cloner/deployment_cloner_test.go
+++ b/test/cloner/deployment_cloner_test.go
@@ -49,8 +49,8 @@ spec:
         - containerPort: 80
 `
 
+//nolint:funlen
 func TestDeploymentImageClone(t *testing.T) {
-
 	client := util.CreateKubernetesClient(t)
 
 	namespace := &corev1.Namespace{}
@@ -81,7 +81,8 @@ func TestDeploymentImageClone(t *testing.T) {
 		t.Fatalf("failed to get destination image: %v", err)
 	}
 
-	deployment, err = client.AppsV1().Deployments(namespace.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	deployment, err = client.AppsV1().Deployments(namespace.Name).Create(
+		context.TODO(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create Deployment: %v", err)
 	}
@@ -90,7 +91,8 @@ func TestDeploymentImageClone(t *testing.T) {
 	// TODO: implement dynamic wait, that checks if the deployment is ready or not before proceeding.
 	time.Sleep(1 * time.Minute)
 
-	deployment, err = client.AppsV1().Deployments(namespace.Name).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	deployment, err = client.AppsV1().Deployments(namespace.Name).Get(
+		context.TODO(), deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to create Deployment: %v", err)
 	}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,3 +1,4 @@
+// Package util handles the utility functions during the tests.
 package util
 
 import (
@@ -20,6 +21,7 @@ const (
 	Timeout = time.Minute * 2
 )
 
+// CreateKubernetesClient creates a Kubernetes client to talk to the API Server.
 func CreateKubernetesClient(t *testing.T) *kubernetes.Clientset {
 	kubeconfigPath := os.ExpandEnv(os.Getenv("KUBECONFIG"))
 	if kubeconfigPath == "" {
@@ -39,12 +41,15 @@ func CreateKubernetesClient(t *testing.T) *kubernetes.Clientset {
 	return cs
 }
 
-func WaitForNamespaceToBeDeleted(t *testing.T, client kubernetes.Interface, name string, retryInterval, timeout time.Duration) {
+// WaitForNamespaceToBeDeleted waits for the namespace to the deleted.
+func WaitForNamespaceToBeDeleted(t *testing.T,
+	client kubernetes.Interface, name string, retryInterval, timeout time.Duration) {
 	if err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
 		_, err = client.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				t.Logf("namespace %s deleted", name)
+
 				return true, nil
 			}
 
@@ -52,7 +57,6 @@ func WaitForNamespaceToBeDeleted(t *testing.T, client kubernetes.Interface, name
 		}
 
 		return false, nil
-
 	}); err != nil {
 		t.Fatalf("waiting for the namespace to be deleted: %v", err)
 	}


### PR DESCRIPTION
Adds `make lint` and `make lint-docker` option to Makefile and enables a sane number of 
golangci-lint linters that help improve the quality and readability of the codebase.


Fixes: #5 